### PR TITLE
Updated the behavior for EXP01 and added security

### DIFF
--- a/posttest/build.gradle
+++ b/posttest/build.gradle
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.postgresql:postgresql'

--- a/posttest/database/init.sql
+++ b/posttest/database/init.sql
@@ -3,13 +3,13 @@ DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS user_lottery;
 
 CREATE TABLE lottery (
-  lottery_id char(6) PRIMARY KEY,
+  lottery_id varchar(6) PRIMARY KEY,
   price numeric(15, 2),
   amount_available int
 );
 
 CREATE TABLE users (
-  user_id char(10) PRIMARY KEY,
+  user_id varchar(10) PRIMARY KEY,
   name varchar(255),
   email varchar(255),
   password varchar(255)
@@ -17,8 +17,8 @@ CREATE TABLE users (
 
 CREATE TABLE user_lottery (
   transaction_id serial PRIMARY KEY,
-  lottery_id char(6) NOT NULL,
-  user_id char(10) NOT NULL,
+  lottery_id varchar(6) NOT NULL,
+  user_id varchar(10) NOT NULL,
   lottery_amount int,
   FOREIGN KEY (lottery_id) REFERENCES lottery (lottery_id),
   FOREIGN KEY (user_id) REFERENCES users (user_id)

--- a/posttest/environments/beta.env
+++ b/posttest/environments/beta.env
@@ -4,6 +4,6 @@ POSTGRES_PASSWORD=password
 POSTGRES_DB=lottery
 
 # Lottery Application Environment Variables
-DATABASE_URL=jdbc:postgresql://localhost:5432/lottery
+DATABASE_URL=jdbc:postgresql://postgresql:5432/lottery
 DATABASE_USERNAME=admin
 DATABASE_PASSWORD=password

--- a/posttest/environments/production.env
+++ b/posttest/environments/production.env
@@ -4,6 +4,6 @@ POSTGRES_PASSWORD=password
 POSTGRES_DB=lottery
 
 # Lottery Application Environment Variables
-DATABASE_URL=jdbc:postgresql://localhost:5432/lottery
+DATABASE_URL=jdbc:postgresql://postgresql:5432/lottery
 DATABASE_USERNAME=admin
 DATABASE_PASSWORD=password

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/api/request/PostLotteryRequest.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/api/request/PostLotteryRequest.java
@@ -5,18 +5,18 @@ import java.math.BigDecimal;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import lombok.NonNull;
 import lombok.Value;
 
 @Value
 @Builder(toBuilder = true)
 public class PostLotteryRequest {
   
-  @NonNull
+  @NotNull
   @NotBlank(message = "Ticket number cannot be empty.")
   @Size(min = 6, max = 6, message = "Ticker number must be exactly 6 digits.")
   @Pattern(regexp = "[0-9]{6}", message = "Ticket number should be from 0-9 for 6 digits. Example: 123456")

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/configuration/SecurityConfiguration.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/configuration/SecurityConfiguration.java
@@ -1,0 +1,54 @@
+package com.kbtg.bootcamp.posttest.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration {
+  
+  @Bean
+  public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity httpSecurity) throws Exception {
+    return httpSecurity
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests((request) ->
+                request
+                    .requestMatchers("/admin/**").hasRole("ADMIN")
+                    .requestMatchers("/**").permitAll()
+                    .anyRequest()
+                    .authenticated())
+            .httpBasic(Customizer.withDefaults())
+            // TODO: add more authentication if time allows
+            .build();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public UserDetailsService userDetailsService() {
+    PasswordEncoder encoder = passwordEncoder();
+
+    UserDetails admin = User.withUsername("admin")
+        .password(encoder.encode("password"))
+        .roles("ADMIN")
+        .build();
+    
+    return new InMemoryUserDetailsManager(admin);
+  }
+}

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/configuration/ServiceConfiguration.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/configuration/ServiceConfiguration.java
@@ -1,8 +1,21 @@
 package com.kbtg.bootcamp.posttest.configuration;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import com.kbtg.bootcamp.posttest.repository.LotteryRepository;
+import com.kbtg.bootcamp.posttest.service.LotteryService;
+
 
 @Configuration
 public class ServiceConfiguration {
-  
+
+  @Autowired
+  LotteryRepository lotteryRepository;
+
+  @Bean
+  public LotteryService lotteryService() {
+    return new LotteryService(lotteryRepository);
+  }
 }

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/entity/Lottery.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/entity/Lottery.java
@@ -2,18 +2,22 @@ package com.kbtg.bootcamp.posttest.entity;
 
 import java.math.BigDecimal;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.Value;
+import lombok.Setter;
 
-@Value
+@Setter
+@Getter
 @Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "lottery")
 public class Lottery {

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/entity/User.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/entity/User.java
@@ -1,14 +1,43 @@
 package com.kbtg.bootcamp.posttest.entity;
 
+import java.util.List;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 import lombok.Value;
 
-@Value
+@Setter
+@Getter
 @Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "users")
 public class User {
 
+  @Id
+  @NonNull
+  String userId;
+
+  @Column(name = "name")
+  String name;
+
+  @Column(name = "email")
+  String email;
+
+  @Column(name = "password")
+  String password;
+
+  @OneToMany(mappedBy = "user", targetEntity = UserLottery.class)
+  List<Lottery> lotteries;
 }

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/entity/UserLottery.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/entity/UserLottery.java
@@ -1,14 +1,37 @@
 package com.kbtg.bootcamp.posttest.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Value;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 
-@Value
+@Setter
+@Getter
 @Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "user_lottery")
 public class UserLottery {
   
+  @Id
+  @NonNull
+  Integer transactionId;
+
+  @ManyToOne
+  @JoinColumn(name = "lottery_id")
+  Lottery lottery;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  User user;
+
+  Integer lotteryAmount;
 }

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/repository/UserLotteryRepository.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/repository/UserLotteryRepository.java
@@ -6,6 +6,6 @@ import org.springframework.stereotype.Repository;
 import com.kbtg.bootcamp.posttest.entity.UserLottery;
 
 @Repository
-public interface UserLotteryRepository extends JpaRepository<UserLottery, Long> {
+public interface UserLotteryRepository extends JpaRepository<UserLottery, Integer> {
   
 }

--- a/posttest/src/main/java/com/kbtg/bootcamp/posttest/service/LotteryService.java
+++ b/posttest/src/main/java/com/kbtg/bootcamp/posttest/service/LotteryService.java
@@ -1,13 +1,41 @@
 package com.kbtg.bootcamp.posttest.service;
 
+import java.util.Optional;
+
 import com.kbtg.bootcamp.posttest.api.request.PostLotteryRequest;
 import com.kbtg.bootcamp.posttest.api.response.PostLotteryResponse;
+import com.kbtg.bootcamp.posttest.entity.Lottery;
+import com.kbtg.bootcamp.posttest.repository.LotteryRepository;
+
+import lombok.NonNull;
 
 public class LotteryService {
 
-  public LotteryService() {}
+  private final LotteryRepository lotteryRepository;
 
-  public PostLotteryResponse createOneLottery(PostLotteryRequest request) {
-    return PostLotteryResponse.builder().lotteryId("test").build();
+  public LotteryService(@NonNull final LotteryRepository lotteryRepository) {
+    this.lotteryRepository = lotteryRepository;
+  }
+
+  public PostLotteryResponse createOneLottery(final PostLotteryRequest request) {
+    String lotteryId = request.getLotteryId();
+    Optional<Lottery> optionalLottery = lotteryRepository.findById(lotteryId);
+
+    int totalAmount = request.getAmount();
+
+    if (optionalLottery.isPresent()) {
+        Lottery existingLottery = optionalLottery.get();
+        totalAmount += existingLottery.getAmountAvailable();
+    }
+
+    Lottery lottery = Lottery.builder()
+        .lotteryId(lotteryId)
+        .price(request.getPrice())
+        .amountAvailable(totalAmount)
+        .build();
+
+    lotteryRepository.save(lottery);
+
+    return PostLotteryResponse.builder().lotteryId(lotteryId).build();
   }
 }


### PR DESCRIPTION
## Summary
- Updated environment variables for beta and prod to point to the correct Postgres URL
- Updated User, UserLottery, and Lottery models with all basic fields
- Changed Lottery createOneLottery behavior to:
  - Add the amount up when the lottery already exists
  - Create a new lottery if the lottery does not exist
- Added security configuration to authenticate admin only for the /admin path, but permit everyone for the rest of the endpoints

## Tests
### Manual Tests
```
docker-compose up
# Service is up
POST:
{
	"ticket": "123456",
	"price": 80,
	"amount": 1
}
# Lottery got created
POST the same request
# Lottery amount got increased

# Added security and repeated the steps above
# The results came out successful
```